### PR TITLE
fix: exports file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
   ],
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs.js",
-      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-apng",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Check if a Buffer/Uint8Array is a APNG (Animated PNG) image",
   "license": "MIT",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ isApng(new Uint8Array(buffer))
 #### As old-school global script tag
 
 Url for latest version: `https://unpkg.com/is-apng`<br>
-Url for specific version: `https://unpkg.com/is-apng@1.0.1/dist/index.js`
+Url for specific version: `https://unpkg.com/is-apng@1.1.0/dist/index.js`
 
 ```html
 <script src="https://unpkg.com/is-apng" type="text/javascript"></script>
@@ -52,12 +52,12 @@ Url for specific version: `https://unpkg.com/is-apng@1.0.1/dist/index.js`
 
 #### As module
 
-Url for latest version: `https://unpkg.com/is-apng/dist/index.esm.js`<br>
-Url for specific version: `https://unpkg.com/is-apng@1.0.1/dist/index.esm.js`
+Url for latest version: `https://unpkg.com/is-apng/dist/index.mjs`<br>
+Url for specific version: `https://unpkg.com/is-apng@1.1.0/dist/index.mjs`
 
 ```html
 <script type="module">
-  import isApng from 'https://unpkg.com/is-apng/dist/index.esm.js'
+  import isApng from 'https://unpkg.com/is-apng/dist/index.mjs'
 
   console.log(typeof isApng);
   // isApng(...)
@@ -72,7 +72,7 @@ or
 <script type="importmap">
   {
     "imports": {
-      "is-apng": "https://unpkg.com/is-apng/dist/index.esm.js"
+      "is-apng": "https://unpkg.com/is-apng/dist/index.mjs"
     }
   }
 </script>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,13 +23,13 @@ export default [
     ],
     output: [
       {
-        file: `${isProduction ? 'dist' : 'lib'}/index.esm.js`,
+        file: `${isProduction ? 'dist' : 'lib'}/index.mjs`,
         format: 'esm',
         // sourcemap: isProduction,
       },
       {
         name: 'isApng',
-        file: `${isProduction ? 'dist' : 'lib'}/index.cjs.js`,
+        file: `${isProduction ? 'dist' : 'lib'}/index.cjs`,
         format: 'cjs',
         // interop: 'auto',
         // sourcemap: isProduction,
@@ -75,7 +75,7 @@ export default [
   //   ],
   //   output: {
   //     name: 'isApng',
-  //     file: `${isProduction ? 'dist' : 'lib'}/index.cjs.js`,
+  //     file: `${isProduction ? 'dist' : 'lib'}/index.cjs`,
   //     format: 'cjs',
   //     // interop: 'default',
   //     interop: 'auto',

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import { readFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import isApng from '../dist/index.esm.js'
+import isApng from '../dist/index.mjs'
 
 const dir =
   typeof __dirname !== 'undefined'

--- a/src/test-browser/index.html
+++ b/src/test-browser/index.html
@@ -10,7 +10,7 @@
     <!-- Module JS -->
     <!--
     <script type="module">
-      import isApng from './js/index.esm.js'
+      import isApng from './js/index.mjs'
 
       if (typeof isApng !== 'function') {
         console.error(


### PR DESCRIPTION
- change `index.cjs.js`, `index.esm.js` to `index.cjs` and index.mjs

### Why

This changes follow the official document of Node.js for `.mjs` and `.cjs` file extension to let Node to interpret the package is an ES module or CJS.

> Authors can tell Node.js to interpret JavaScript as an ES module via the .mjs file extension, the package.json "type" field with a value "module", the --input-type flag with a value of "module", or the --experimental-default-type flag with a value of "module". These are explicit markers of code being intended to run as an ES module.
> 
> Inversely, authors can tell Node.js to interpret JavaScript as CommonJS via the .cjs file extension, the package.json "type" field with a value "commonjs", the --input-type flag with a value of "commonjs", or the --experimental-default-type flag with a value of "commonjs".

[Reference](https://nodejs.org/docs/latest/api/esm.html#esm_differences_between_es_modules_and_commonjs)

It also fix errors from Node.js build
```
ReferenceError: module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and './node_modules/is-apng/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```