### PR TITLE
Stop search immediately after finding acTL chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-apng",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "Check if a Buffer/Uint8Array is a APNG (Animated PNG) image",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-apng",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Check if a Buffer/Uint8Array is a APNG (Animated PNG) image",
   "license": "MIT",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ isApng(new Uint8Array(buffer))
 #### As old-school global script tag
 
 Url for latest version: `https://unpkg.com/is-apng`<br>
-Url for specific version: `https://unpkg.com/is-apng@1.1.2/dist/index.js`
+Url for specific version: `https://unpkg.com/is-apng@1.1.3/dist/index.js`
 
 ```html
 <script src="https://unpkg.com/is-apng" type="text/javascript"></script>
@@ -53,7 +53,7 @@ Url for specific version: `https://unpkg.com/is-apng@1.1.2/dist/index.js`
 #### As module
 
 Url for latest version: `https://unpkg.com/is-apng/dist/index.mjs`<br>
-Url for specific version: `https://unpkg.com/is-apng@1.1.2/dist/index.mjs`
+Url for specific version: `https://unpkg.com/is-apng@1.1.3/dist/index.mjs`
 
 ```html
 <script type="module">

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ export default function isApng(buffer: Buffer | Uint8Array): boolean {
 
   buffer = buffer.subarray(8)
 
-  let foundFirst = false
   let firstIndex = 0
   let secondIndex = 0
   for (let i = 0; i < buffer.length; i++) {
@@ -48,7 +47,7 @@ export default function isApng(buffer: Buffer | Uint8Array): boolean {
     ) {
       firstIndex++
       if (firstIndex === sequences.animationControlChunk.length) {
-        foundFirst = true
+        return true
       }
     }
 
@@ -60,7 +59,7 @@ export default function isApng(buffer: Buffer | Uint8Array): boolean {
     ) {
       secondIndex++
       if (secondIndex === sequences.imageDataChunk.length) {
-        return foundFirst
+        return false
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,25 +38,22 @@ export default function isApng(buffer: Buffer | Uint8Array): boolean {
   let firstIndex = 0
   let secondIndex = 0
   for (let i = 0; i < buffer.length; i++) {
-    if (
-      !foundFirst &&
-      (buffer[i] === sequences.animationControlChunk[firstIndex] ||
-        (firstIndex > 0 &&
-          ((firstIndex = 0) ||
-            buffer[i] === sequences.animationControlChunk[firstIndex])))
-    ) {
+    if (buffer[i] !== sequences.animationControlChunk[firstIndex]) {
+      firstIndex = 0
+    }
+
+    if (buffer[i] === sequences.animationControlChunk[firstIndex]) {
       firstIndex++
       if (firstIndex === sequences.animationControlChunk.length) {
         return true
       }
     }
 
-    if (
-      buffer[i] === sequences.imageDataChunk[secondIndex] ||
-      (secondIndex > 0 &&
-        ((secondIndex = 0) ||
-          buffer[i] === sequences.imageDataChunk[secondIndex]))
-    ) {
+    if (buffer[i] !== sequences.imageDataChunk[secondIndex]) {
+      secondIndex = 0
+    }
+
+    if (buffer[i] === sequences.imageDataChunk[secondIndex]) {
       secondIndex++
       if (secondIndex === sequences.imageDataChunk.length) {
         return false


### PR DESCRIPTION
I believe there is no need to continue searching for `IDAT` if `acTL` is found, since it's existence is guaranteed by PNG spec